### PR TITLE
Mac Chromeでエラーfix

### DIFF
--- a/qr-web-2/js/index.js
+++ b/qr-web-2/js/index.js
@@ -8,9 +8,7 @@
 
   navigator.getUserMedia({
     video: {
-      facingMode : {
-        exact : "environment"
-      }
+      facingMode: "user"
     }, audio: false
   }, _handleSuccess, _handleError);
 


### PR DESCRIPTION
Mac OS 10.13.6
Chrome  69.0.3497.100
でエラーとなり使えなかったのが、この部分を直して動くようになりました。